### PR TITLE
Tradução do Capítulo-01-01: Instalação

### DIFF
--- a/second-edition/src/ch01-01-installation.md
+++ b/second-edition/src/ch01-01-installation.md
@@ -1,110 +1,96 @@
 ## Installation
 
-The first step to using Rust is to install it. We’ll download Rust through
-`rustup`, a command-line tool for managing Rust versions and associated tools.
-For this you’ll need an internet connection.
+The first step is to install Rust. We’ll download Rust through `rustup`, a
+command line tool for managing Rust versions and associated tools. You’ll need
+an internet connection for the download.
 
-The following steps will install the latest stable version of the Rust
-compiler. The examples and output shown in this book all use stable Rust
-1.21.0. Rust’s stability guarantees ensure that all of the examples in the book
-that compile will continue to compile with newer versions of Rust. The output
-may differ slightly between versions, as error messages and warnings are often
-improved. In other words, any newer, stable version of Rust you will install
-with these steps should work as expected with the content of this book.
+> Note: If you prefer not to use `rustup` for some reason, please see [the Rust
+> installation page](https://www.rust-lang.org/tools/install) for other options.
 
-<!-- PROD: Start Box -->
+The following steps install the latest stable version of the Rust compiler.
+Rust’s stability guarantees ensure that all the examples in the book that
+compile will continue to compile with newer Rust versions. The output might
+differ slightly between versions, because Rust often improves error messages
+and warnings. In other words, any newer, stable version of Rust you install
+using these steps should work as expected with the content of this book.
 
-> #### Command Line Notation
+> ### Command Line Notation
 >
-> In this chapter and throughout the book we’ll be showing some commands used
-> in the terminal. Lines that should be entered in a terminal all start with
-> `$`. You don’t need to type in the `$` character, it is simply there to
-> indicate the start of each command. Many tutorials use this convention: `$`
-> for commands run as a regular user, and `#` for commands you should be
-> running as an administrator. Lines that don’t start with `$` are typically
-> showing the output of the previous command. Additionally, PowerShell specific
-> examples will use `>` rather than `$`.
+> In this chapter and throughout the book, we’ll show some commands used in the
+> terminal. Lines that you should enter in a terminal all start with `$`. You
+> don’t need to type in the `$` character; it indicates the start of each
+> command. Lines that don’t start with `$` typically show the output of the
+> previous command. Additionally, PowerShell-specific examples will use `>`
+> rather than `$`.
 
-<!-- PROD: End box -->
+### Installing `rustup` on Linux or macOS
 
-### Installing Rustup on Linux or Mac
-
-If you’re on Linux or a Mac, open a terminal and enter the following command:
+If you’re using Linux or macOS, open a terminal and enter the following command:
 
 ```text
 $ curl https://sh.rustup.rs -sSf | sh
 ```
 
-This will download a script and start the installation of the `rustup` tool,
-which installs the latest stable version of Rust. You may be prompted for your
-password. If it all goes well, you’ll see this appear:
+The command downloads a script and starts the installation of the `rustup`
+tool, which installs the latest stable version of Rust. You might be prompted
+for your password. If the install is successful, the following line will appear:
 
 ```text
 Rust is installed now. Great!
 ```
 
-Of course, if you distrust using `curl URL | sh` to install software, you can
-download, inspect, and run the script however you like.
+If you prefer, feel free to download the script and inspect it before running
+it.
 
 The installation script automatically adds Rust to your system PATH after your
 next login. If you want to start using Rust right away instead of restarting
 your terminal, run the following command in your shell to add Rust to your
 system PATH manually:
 
-<!-- what does this command do? Do you mean instead of logging out and logging
-in, enter the following? -->
-<!-- It runs a script that adds Rust to your system PATH manually. I've
-clarified that yes, this is instead of logging out and back in to your
-terminal. /Carol -->
-
 ```text
 $ source $HOME/.cargo/env
 ```
 
-Alternatively, you can add the following line to your `~/.bash_profile`:
+Alternatively, you can add the following line to your _~/.bash_profile_:
 
 ```text
 $ export PATH="$HOME/.cargo/bin:$PATH"
 ```
 
-Finally, you’ll need a linker of some kind. It’s likely you already have one
-installed, but if you try to compile a Rust program and get errors telling you
-that a linker could not be executed, you’ll need to install one. You can
-install a C compiler, as that will usually come with the correct linker. Check
-your platform’s documentation for how to install a C compiler. Some common Rust
-packages depend on C code and will need a C compiler too, so it may be worth
-installing one now regardless.
+Additionally, you’ll need a linker of some kind. It’s likely one is already
+installed, but when you try to compile a Rust program and get errors indicating
+that a linker could not execute, that means a linker isn’t installed on your
+system and you’ll need to install one manually. C compilers usually come with
+the correct linker. Check your platform’s documentation for how to install a C
+compiler. Also, some common Rust packages depend on C code and will need a C
+compiler. Therefore, it might be worth installing one now.
 
-### Installing Rustup on Windows
+### Installing `rustup` on Windows
 
-On Windows, go to [https://www.rust-lang.org/en-US/install.html][install] and
-follow the instructions for installing Rust. At some point in the installation
-you’ll receive a message telling you you’ll also need the C++ build tools for
+On Windows, go to [https://www.rust-lang.org/tools/install][install] and follow
+the instructions for installing Rust. At some point in the installation, you’ll
+receive a message explaining that you’ll also need the C++ build tools for
 Visual Studio 2013 or later. The easiest way to acquire the build tools is to
-install [Build Tools for Visual Studio 2017][visualstudio], found in the Other
-Tools and Frameworks section.
+install [Build Tools for Visual Studio 2019][visualstudio]. The tools are in
+the Other Tools and Frameworks section.
 
-[install]: https://www.rust-lang.org/en-US/install.html
-[visualstudio]: https://www.visualstudio.com/downloads/
+[install]: https://www.rust-lang.org/tools/install
+[visualstudio]: https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019
 
-The rest of this book will use commands that work in both `cmd.exe` and
-PowerShell. If there are specific differences, we’ll explain which to use.
-
-### Custom Installations Without Rustup
-
-If you have reasons for preferring not to use `rustup`, please see [the Rust
-installation page](https://www.rust-lang.org/install.html) for other options.
+The rest of this book uses commands that work in both _cmd.exe_ and PowerShell.
+If there are specific differences, we’ll explain which to use.
 
 ### Updating and Uninstalling
 
-Once you have Rust installed via `rustup`, updating to the latest version is
-easy. From your shell, run the update script:
+After you’ve installed Rust via `rustup`, updating to the latest version is
+easy. From your shell, run the following update script:
 
 ```text
 $ rustup update
 ```
 
-To uninstall Rust and `rustup`, from your shell, run the uninstall script:
+To uninstall Rust and `rustup`, run the following uninstall script from your
+shell:
 
 ```text
 $ rustup self uninstall
@@ -112,34 +98,29 @@ $ rustup self uninstall
 
 ### Troubleshooting
 
-To check whether you have Rust installed correctly, open up a shell and enter:
+To check whether you have Rust installed correctly, open a shell and enter this
+line:
 
 ```text
 $ rustc --version
 ```
 
 You should see the version number, commit hash, and commit date for the latest
-stable version at the time you install in the following format:
+stable version that has been released in the following format:
 
 ```text
 rustc x.y.z (abcabcabc yyyy-mm-dd)
 ```
 
-If you see this, Rust has been installed successfully! Congrats!
+If you see this information, you have installed Rust successfully! If you don’t
+see this information and you’re on Windows, check that Rust is in your `%PATH%`
+system variable. If that’s all correct and Rust still isn’t working, there are
+a number of places you can get help. The easiest is the #beginners channel on
+[the official Rust Discord][discord]. There, you can chat with other Rustaceans
+(a silly nickname we call ourselves) who can help you out. Other great
+resources include [the Users forum][users] and [Stack Overflow][stackoverflow].
 
-If you don’t and you’re on Windows, check that Rust is in your `%PATH%` system
-variable.
-
-If that’s all correct and Rust still isn’t working, there are a number of
-places you can get help. The easiest is [the #rust IRC channel on
-irc.mozilla.org][irc]<!-- ignore -->, which you can access through
-[Mibbit][mibbit]. Go to that address, and you’ll be chatting with other
-Rustaceans (a silly nickname we call ourselves) who can help you out. Other
-great resources include [the Users forum][users] and [Stack
-Overflow][stackoverflow].
-
-[irc]: irc://irc.mozilla.org/#rust
-[mibbit]: http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
+[discord]: https://discord.gg/rust-lang
 [users]: https://users.rust-lang.org/
 [stackoverflow]: http://stackoverflow.com/questions/tagged/rust
 
@@ -149,6 +130,6 @@ The installer also includes a copy of the documentation locally, so you can
 read it offline. Run `rustup doc` to open the local documentation in your
 browser.
 
-Any time there’s a type or function provided by the standard library and you’re
-not sure what it does or how to use it, use the API (Application Programming
-Interface) documentation to find out!
+Any time a type or function is provided by the standard library and you’re not
+sure what it does or how to use it, use the application programming interface
+(API) documentation to find out!

--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -1,45 +1,61 @@
 ## Instalação
 
-O primeiro passo para se usar a linguagem Rust é instalá-la. Você vai precisar
-de uma conexão com a internet para executar os comandos contidos neste
-capítulo, pois vamos baixar o Rust da internet.
+O primeiro passo é instalar Rust. Nós vamos baixar Rust através do `rustup`,
+uma ferramenta de linha de comando para gerenciar versões de Rust e ferramentas
+associadas. Você vai precisar de uma conexão com a internet para executar o
+download.
 
-Iremos mostrar diversos comandos usando o terminal, e todas as linhas que se
-referem ao terminal iniciam com `$`. Você não precisa digitar o caractere `$`,
-ele serve apenas para indicar o início de cada comando. Você vai notar que
-muitos tutorias disponíveis por aí seguem esta convenção: `$` para comandos que
-são executados como um usuário normal, e `#` para comandos que você deve
-executar como administrador. As linhas que não iniciam com o caractere `$`
-mostram o _output_ (saída) do comando anterior.
+> Nota: se você prefere não usar o `rustup` por algum motivo, por favor veja o
+> [a página de instalação de Rust](https://www.rust-lang.org/tools/install)
+> para outras opções.
 
-### Instalando no Linux ou Mac
+Os próximos passos irão instalar a última versão estável do compilador de Rust.
+A garantias de estabilidade de Rust certificam-se de que todos os exemplos
+neste livro que compilam vao continuar a compilar com novas versões de Rust.
+As saídas podem variar um pouco de versão a versão, porque Rust frequentemente
+melhora mensagens de erro e alertas. Em outras palavras, qualquer versão nova,
+estável, de Rust qu você instalar usando esses passos devem funcionar como o
+esperado com o conteúdo deste livro.
 
-Se você está em um ambiente Linux ou Mac, tudo o que você precisa é abrir um
-terminal e digitar o seguinte comando:
+> ### Notação de Linha de Comando
+>
+> Neste capítulo e ao longo do livro, nós iremos mostrar alguns comandos usados
+> no terminal. Linhas que você deve digitar num terminal todas começam com `$`.
+> Você não precisa digitar o caráctere `$`. Ele indica o início de cada comando.
+> Linhas que não comecem com `$` tipicamente mostram a saída do comando anterior.
+> Adicionalmente, exemplos específicos de PowerShell irão utilizar `>` ao invés
+> de `$`.
+
+### Instalando `rustup` em Linux ou Mac
+
+Se você utiliza Linux ou Mac, abra um terminal e digite o seguinte comando:
 
 ```text
 $ curl https://sh.rustup.rs -sSf | sh
 ```
 
-Este comando vai baixar um script e iniciar a instalação. Talvez seja solicitado
-que você digite sua senha. Se tudo ocorrer bem, a mensagem abaixo vai aparecer:
+Este comando baixa um script e inicia a instalação da ferramenta `rustup`, a
+qual instala a última versão estável de Rust. Talvez seja solicitado que você
+digite sua senha. Se a instalação for bem-sucedida, a seguinte linha irá
+aparecer:
 
 ```text
 Rust is installed now. Great!
 ```
 
-Claro, se você não aprova o uso do `curl | sh`, você pode baixar o _script_,
-inspecioná-lo e executá-lo da maneira que achar melhor.
+Se preferir, sinta-se livre para baixar o script e inspecioná-lo antes de
+executar.
 
-O _script_ de instalação já adiciona automaticamente o Rust à variável PATH do
-seu sistema logo após o seu próximo _login_. Se você quiser usar o Rust
-imediatamente, execute o seguinte comando no seu terminal:
+O script de instalação adiciona automaticamente Rust à variável PATH do
+seu ambiente após o seu próximo login. Se você quiser usar Rust imediatamente
+ao invés de reiniciar o seu terminal, execute o seguinte comando no seu shell
+para adicionar Rust à PATH do seu sistema manualmente:
 
 ```text
 $ source $HOME/.cargo/env
 ```
 
-Outra opção é adicionar a linha abaixo no seu `~/.bash_profile`:
+Outra opção é adicionar a linha abaixo ao seu `~/.bash_profile`:
 
 ```text
 $ export PATH="$HOME/.cargo/bin:$PATH"
@@ -47,36 +63,32 @@ $ export PATH="$HOME/.cargo/bin:$PATH"
 
 ### Instalando no Windows
 
-No Windows, visite o _site_
-[https://rustup.rs](https://rustup.rs/)<!-- ignore --> e siga as instruções para
-baixar o arquivo rustup-init.exe. Execute este arquivo e siga as demais
-instruções que aparecerem na sua tela.
+No Windows, vá até [https://www.rust-lang.org/tools/install][install] e siga
+as instruções para instalar Rust. Em algum ponto da instalação, você receberá
+uma mensagem explicando que você também irá precisar de ferramentas de
+compilação de C++ para o Visual Studio 2013 ou superior. A forma mais fácil de
+adquiri-las é instalando as [Ferramentas de Compilação para o Visual 
+Studio 2019][visualstudio]. As ferramentas estão na seção Other Tools and
+Frameworks.
 
-O restante dos comandos específicos do Windows neste livro partem da premissa de
-que você está utilizando o `cmd` como o seu _shell_. Se você está usando um
-_shell_ diferente, talvez você poderá usar os mesmos comandos que os usuários de
-Linux ou Mac usam. Se algum comando não funcionar, consulte a documentação
-referente ao _shell_ que você está utilizando.
+[install]: https://www.rust-lang.org/tools/install
+[visualstudio]: https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019
 
-### Instalação customizada
+O restante deste livro utiliza comandos que funcionam tanto no *cmd.exe* quanto
+no PowerShell. Se existirem diferenças específicas, nós iremos apontar qual 
+utilizar.
 
-Se, por alguma razão, você preferir não usar o rustup.rs, consulte [a página de
-instalação do Rust](https://www.rust-lang.org/pt-BR/install.html) para outras
-opções de instalação.
+### Atualizando e desinstalando
 
-### Atualizando o Rust
-
-Tendo o Rust instalado na sua máquina, atualizar para a última versão é fácil.
-Do seu _shell_, execute o _script_ de atualização:
+Após instalar Rust pelo `rustup`, atualizar para a última versão é fácil.
+Do seu seu shell, rode o seguinte script de atualização:
 
 ```text
 $ rustup update
 ```
 
-### Desinstalando
-
-Desinstalar Rust é tão fácil quanto instalá-lo. Do seu _shell_, execute o
-_script_ de desinstalação:
+Para desinstalar Rust e o `rustup`, rode o seguinte script de desinstalação do
+seu shell:
 
 ```text
 $ rustup self uninstall
@@ -84,45 +96,39 @@ $ rustup self uninstall
 
 ### Solução de Problemas
 
-Após Rust ser instalado em sua máquina, você pode abrir o seu _shell_, e digitar
-a linha abaixo:
+Para checar se você tem Rust instalado corretamente, abra um terminal e digite
+esta linha:
 
 ```text
 $ rustc --version
 ```
 
-Você deverá ver a versão, o _hash_ e a data do _commit_ em um formato
-similar ao seguinte, indicando a última estável mais recente no momento da
-instalação:
+Você deverá ver o número, o hash e a data do commit da última versão estável
+lançada no seguinte formato:
 
 ```text
 rustc x.y.z (abcabcabc yyyy-mm-dd)
 ```
 
-Se aparecer a mensagem acima, Rust foi instalado com sucesso!
-Parabéns!
+Se aparecer a mensagem acima, você instalou Rust com sucesso! Se você não ver
+esta informação e você estiver no Windows, cheque que Rust está na sua variável
+de ambiente `%PATH%`. Se tudo isso estiver correto e Rust ainda não funcionar,
+existem vários locais em que você pode pedir ajuda. O mais fácil é o canal
+#beginners no [Discord oficial de Rust][discord]. Lá, você pode falar com
+outros Rustáceos (um apelido bobo que damos a nós mesmos) que podem te ajudar.
+Outros ótimos recursos incluem [o fórum de usários][users] e o [Stack
+Overflow][stackoverflow].
 
-Se não aparecer a mensagem acima e você está em um ambiente Windows, verifique
-se o Rust aparece na variável `%PATH%` do seu sistema.
-
-Se mesmo assim não funcionar, existem vários lugares onde você pode pedir ajuda.
-A maneira mais fácil é pedir ajuda no
-[canal IRC #rust do irc.mozilla.org][irc]<!-- ignore -->, que você pode acessar
-via [Mibbit][mibbit]. Você vai falar com vários outros _Rustaceans_ (um apelido
-bobo que usamos entre nós) que podem ajudá-lo em suas dúvidas. Você também pode
-buscar ajuda no [fórum do Rust][users] e no [Stack Overflow][stackoverflow].
-
-[irc]: irc://irc.mozilla.org/#rust
-[mibbit]: http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
+[discord]: https://discord.gg/rust-lang
 [users]: https://users.rust-lang.org/
 [stackoverflow]: http://stackoverflow.com/questions/tagged/rust
 
 ### Documentação local
 
 O instalador também inclui uma cópia local da documentação para que você possa
-acessá-la _offline_. Execute o comando `rustup doc` para abrir a documentação
-local no seu navegador.
+acessá-la offline. Execute o comando `rustup doc` para abrir a documentação no
+seu navegador.
 
-Sempre que você se deparar com um tipo ou função fornecido pela biblioteca
-padrão que você não tem certeza do que ele faz, use a documentação da API para
+Sempre que um tipo ou for fornecido pela biblioteca padrão e você não tiver
+certeza do que ele faz ou de como usá-lo, use a documentação da API para
 descobrir!


### PR DESCRIPTION
## Contexto
O livro original sofreu várias atualizações desde que esse projeto começou. Muito do que havia sido traduzido terá que ser atualizado. 

A página de instruções de instalação de rust estava em grande parte atualizada. Apenas devemos atualizar o que mudou.

Atualizei a versão em `second-edition/src` e atualizei alguns trechos desatualizados da versão em `src`.

[Issue](https://github.com/rust-br/rust-book-pt-br/issues/81)