### PR TITLE
Atualiza mdbook para 0.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
 - stable
 install:
 - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git rust-lang-nursery/mdBook
-  --crate mdbook --force --target x86_64-unknown-linux-gnu --tag v0.1.2
+  --crate mdbook --force --target x86_64-unknown-linux-gnu --tag v0.4.0
 script:
 - mdbook build
 deploy:


### PR DESCRIPTION
De acordo com o livro original:

https://github.com/rust-lang/book#requirements

Que leva a

https://github.com/rust-lang/rust/blob/master/src/tools/rustbook/Cargo.toml