### PR TITLE
Adiciona ajuste capitulo 2 linha 311 onde utiliza a palavra guest ao invés de palpite

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -308,7 +308,7 @@ Tirando a chave que delimita a função `main`, há apenas uma linha mais a ser
 discutida no código que fizemos até agora, que é a seguinte:
 
 ```rust,ignore
-println!("Você disse: {}", guess);
+println!("Você disse: {}", palpite);
 ```
 
 Esta linha imprime a string na qual salvamos os dados inseridos pelo usuário. O


### PR DESCRIPTION
Adiciona ajuste capitulo 2 linha 311 onde utiliza a palavra guest ao invés de palpite que pode gerar confusão com o contexto anterior


